### PR TITLE
fix unlink deprecation

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ googleCodeJamIo.appendToFile = function(str, suffix) {
 googleCodeJamIo.deleteOutputFile = function() {
   fs.exists(googleCodeJamIo.outputFile, function(exists) {
     if (exists) {
-      fs.unlink(googleCodeJamIo.outputFile);
+      fs.unlinkSync(googleCodeJamIo.outputFile);
     }
   })
 };


### PR DESCRIPTION
This fix "DeprecationWarning: Calling an asynchronous function without callback is deprecated." for fs.unlink().